### PR TITLE
Handle PRG‑RAM banks and extended RAM detection

### DIFF
--- a/nes_py/_rom.py
+++ b/nes_py/_rom.py
@@ -132,6 +132,11 @@ class ROM(object):
         return bool(int(self.flags_6[6]))
 
     @property
+    def has_extended_ram(self):
+        """Return whether this ROM contains any PRG-RAM."""
+        return self.prg_ram_size > 0 or self.has_battery_backed_ram
+
+    @property
     def is_vertical_mirroring(self):
         """Return the mirroring mode this ROM uses."""
         return bool(int(self.flags_6[7]))

--- a/nes_py/nes/include/cartridge.hpp
+++ b/nes_py/nes/include/cartridge.hpp
@@ -27,13 +27,16 @@ class Cartridge {
     NES_Byte mapper_number;
     /// whether this cartridge uses extended RAM
     bool has_extended_ram;
+    /// the number of 8KB PRG-RAM banks detected
+    std::size_t prg_ram_banks;
 
  public:
     /// Initialize a new cartridge
     Cartridge() :
         name_table_mirroring(0),
         mapper_number(0),
-        has_extended_ram(false) { }
+        has_extended_ram(false),
+        prg_ram_banks(0) { }
 
     /// Return the ROM data.
     const inline std::vector<NES_Byte>& getROM() { return prg_rom; }
@@ -49,6 +52,9 @@ class Cartridge {
 
     /// Return a boolean determining whether this cartridge uses extended RAM.
     inline bool hasExtendedRAM() { return has_extended_ram; }
+
+    /// Return the number of 8KB PRG-RAM banks on this cartridge.
+    inline std::size_t getPRGRAMBankCount() { return prg_ram_banks; }
 
     /// Load a ROM file into the cartridge and build the corresponding mapper.
     void loadFromFile(std::string path);

--- a/nes_py/nes/include/mapper.hpp
+++ b/nes_py/nes/include/mapper.hpp
@@ -44,6 +44,9 @@ class Mapper {
     /// Return true if this mapper has extended RAM, false otherwise.
     inline bool hasExtendedRAM() { return cartridge->hasExtendedRAM(); }
 
+    /// Return the number of 8KB PRG-RAM banks on the cartridge.
+    inline std::size_t getPRGRAMBankCount() { return cartridge->getPRGRAMBankCount(); }
+
     /// Return true if PRG-RAM is enabled and should be accessible.
     inline virtual bool isPRGRAMEnabled() { return true; }
 

--- a/nes_py/nes/src/cartridge.cpp
+++ b/nes_py/nes/src/cartridge.cpp
@@ -21,7 +21,8 @@ void Cartridge::loadFromFile(std::string path) {
     // read internal data
     name_table_mirroring = header[6] & 0xB;
     mapper_number = ((header[6] >> 4) & 0xf) | (header[7] & 0xf0);
-    has_extended_ram = header[6] & 0x2;
+    prg_ram_banks = header[8] ? header[8] : 1;
+    has_extended_ram = (prg_ram_banks != 0) || (header[6] & 0x2);
     // read PRG-ROM 16KB banks
     NES_Byte banks = header[4];
     prg_rom.resize(0x4000 * banks);

--- a/nes_py/nes/src/main_bus.cpp
+++ b/nes_py/nes/src/main_bus.cpp
@@ -93,8 +93,12 @@ const NES_Byte* MainBus::get_page_pointer(NES_Byte page) {
 
 void MainBus::set_mapper(Mapper* mapper) {
     this->mapper = mapper;
-    if (mapper->hasExtendedRAM())
-        extended_ram.resize(0x2000);
+    if (mapper->hasExtendedRAM()) {
+        std::size_t banks = mapper->getPRGRAMBankCount();
+        if (banks == 0)
+            banks = 1;
+        extended_ram.resize(banks * 0x2000);
+    }
 }
 
 }  // namespace NES

--- a/nes_py/tests/test_rom.py
+++ b/nes_py/tests/test_rom.py
@@ -321,3 +321,13 @@ class ShouldReadLegendOfZelda(ShouldReadROMHeaderTestCase, TestCase):
     prg_rom_stop = 16 + 128 * 2**10
     chr_rom_start = 16 + 128 * 2**10
     chr_rom_stop = (16 + 128 * 2**10) + 0
+
+
+class ShouldDetectExtendedRAM(TestCase):
+    """Check extended RAM detection for ROMs without battery-backed RAM."""
+
+    def test_super_mario_bros_3_has_extended_ram(self):
+        rom_path = rom_file_abs_path('super-mario-bros-3.nes')
+        rom = ROM(rom_path)
+        self.assertTrue(rom.has_extended_ram)
+        self.assertFalse(rom.has_battery_backed_ram)


### PR DESCRIPTION
## Summary
- compute PRG‑RAM bank count from iNES header
- expose PRG‑RAM bank count through cartridge/mapper
- size MainBus extended RAM based on bank count
- expose `has_extended_ram` on ROM
- test that SMB3 reports extended RAM despite no battery

## Testing
- `make test`


------
https://chatgpt.com/codex/tasks/task_e_688ce527fa24832c9de0f7810dc4e2e4