### PR TITLE
Fix extended RAM detection

### DIFF
--- a/nes_py/nes/src/cartridge.cpp
+++ b/nes_py/nes/src/cartridge.cpp
@@ -21,8 +21,14 @@ void Cartridge::loadFromFile(std::string path) {
     // read internal data
     name_table_mirroring = header[6] & 0xB;
     mapper_number = ((header[6] >> 4) & 0xf) | (header[7] & 0xf0);
+    // determine the number of PRG-RAM banks; if the header reports 0,
+    // default to a single 8KB bank for compatibility.
     prg_ram_banks = header[8];
-    has_extended_ram = (header[8] != 0) || (header[6] & 0x2);
+    if (prg_ram_banks == 0)
+        prg_ram_banks = 1;
+    // extended RAM is available when PRG-RAM exists or the cartridge
+    // specifies battery-backed RAM in the mapper flags
+    has_extended_ram = (prg_ram_banks != 0) || (header[6] & 0x2);
     // read PRG-ROM 16KB banks
     NES_Byte banks = header[4];
     prg_rom.resize(0x4000 * banks);


### PR DESCRIPTION
## Summary
- correct PRG RAM bank detection logic in `Cartridge::loadFromFile`
- mark cartridges as having extended RAM after the PRG RAM bank count is finalized
- rebuild C++ extension and run unit tests

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688d07b0abcc832c9af83688c426c29f