### PR TITLE
Fix MMC3 IRQ timing and add SMB3 regression test

### DIFF
--- a/nes_py/nes/src/mappers/mapper_MMC3.cpp
+++ b/nes_py/nes/src/mappers/mapper_MMC3.cpp
@@ -164,10 +164,12 @@ void MapperMMC3::update_banks() {
 void MapperMMC3::clock_irq(NES_Address address) {
     bool a12 = address & 0x1000;
     if (!a12) {
-        if (a12_low_counter < 3)
+        if (a12_low_counter < 0xff)
             ++a12_low_counter;
+        if (a12_low_counter > 15)
+            irq_active = false;  // clear pending IRQ each frame
     }
-    if (a12 && !prev_a12 && a12_low_counter >= 3) {
+    if (a12 && !prev_a12 && a12_low_counter >= 6) {
         if (irq_counter == 0 || irq_reload) {
             irq_counter = irq_latch;
             irq_reload = false;

--- a/nes_py/tests/test_mmc3_irq.py
+++ b/nes_py/tests/test_mmc3_irq.py
@@ -1,0 +1,36 @@
+from unittest import TestCase
+import numpy as np
+from nes_py.nes_env import NESEnv
+from nes_py.tests.rom_file_abs_path import rom_file_abs_path
+
+RIGHT = 0b10000000
+START = 0b00001000
+A = 0b00000001
+
+class ShouldKeepStatusBarStatic(TestCase):
+    def test(self):
+        env = NESEnv(rom_file_abs_path('super-mario-bros-3.nes'))
+        env.reset()
+        # Skip the initial screen
+        for _ in range(60):
+            env.step(0)
+        # Press start twice to reach the world map
+        for _ in range(5):
+            env.step(START)
+        for _ in range(10):
+            env.step(0)
+        for _ in range(5):
+            env.step(START)
+        for _ in range(20):
+            env.step(0)
+        # Enter the first level
+        env.step(A)
+        for _ in range(60):
+            state, _, _, _ = env.step(0)
+        before = state[224:].copy()
+        # Move right for a while
+        for _ in range(120):
+            state, _, _, _ = env.step(RIGHT)
+        after = state[224:]
+        env.close()
+        self.assertTrue(np.array_equal(before, after))


### PR DESCRIPTION
## Summary
- tweak MMC3 IRQ edge detection to require longer A12 low period
- clear pending IRQ after long A12 low time
- add regression test for Super Mario Bros. 3 to verify status bar stays fixed

## Testing
- `make test`

------
https://chatgpt.com/codex/tasks/task_e_688d127197d0832ca3f8c5518403a8de